### PR TITLE
Fix encoding of length delimited fields / packed arrays

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -227,13 +227,13 @@ tap.test('Mapping', (t: TestSuite) => {
 
 const sampleData = {
   locationId: [1, 2, 3],
-  value: [4, 5, 0, 6],
+  value: [...Array(180).keys()],
   label: [labelData]
 }
 
 const sampleEncodings = [
   { field: 'locationId', value: '0a03010203' },
-  { field: 'value', value: '120404050006' },
+  { field: 'value', value: embeddedField('12', sampleData.value.map(x => ({field: '', value: hexVarInt(x)}))) },
   { field: 'label', value: embeddedField('1a', labelEncodings) },
 ]
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,12 +184,16 @@ function measureNumberArrayField(values: Numeric[]): number {
     // Arrays should always include zeros to keep positions consistent
     total += measureNumber(value) || 1
   }
-  return total ? 2 + total : 0
+  // Packed arrays are encoded as Tag,Len,ConcatenatedElements
+  // Tag is only one byte because field number is always < 16 in pprof
+  return total ? 1 + measureNumber(total) + total : 0
 }
 
 function measureLengthDelimField<T>(value: T): number {
   const length = measureValue(value)
-  return length ? 2 + length : 0
+  // Length delimited records / submessages are encoded as Tag,Len,EncodedRecord
+  // Tag is only one byte because field number is always < 16 in pprof
+  return length ? 1 + measureNumber(length) + length : 0
 }
 
 function measureLengthDelimArrayField<T>(values: T[]): number {


### PR DESCRIPTION
Code was incorrectly assuming that LEN could always be encoded on 1 byte. LEN is encoded as a varint and should be properly measured.