### PR TITLE
Avoid n^2 complexity during decoding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,11 @@ function decodeNumbers(buffer: Uint8Array): Array<Numeric> {
 }
 
 function push<T>(value: T, list?: Array<T>): Array<T> {
-  return Array.isArray(list) ? list.concat(value) : [value]
+  if (list == null) {
+    return [value]
+  }
+  list.push(value)
+  return list
 }
 
 function measureNumber(number: Numeric): number {


### PR DESCRIPTION
`push` using `Array.concat` creates a new copy of the array for each inserted element and leads to n^2 complexity when decoding arrays. For pprof with large numbers of samples, this quickly leads to very long decoding (>1 min) compared to ~1s with this change.