### PR TITLE
feat: Strip testing from published artifact

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ src
 tsconfig.json
 example.js
 .gitignore
+testing/


### PR DESCRIPTION
This should save about 200kB from the build

Before:
```
> npm pack
npm notice
npm notice 📦  pprof-format@2.0.4
npm notice === Tarball Contents ===
npm notice 555B    .github/ISSUE_TEMPLATE/bug_report.md
npm notice 119B    .github/ISSUE_TEMPLATE/feature_request.md
npm notice 573B    .github/workflows/ci.yml
npm notice 1.7kB   .github/workflows/codeql.yml
npm notice 582B    .github/workflows/package-size.yml
npm notice 352B    .github/workflows/pr-labels.yml
npm notice 714B    .github/workflows/release.yml
npm notice 329B    CONTRIBUTING.md
npm notice 1.1kB   LICENSE
npm notice 569B    LICENSE-3rdparty.csv
npm notice 147B    NOTICE
npm notice 2.1kB   README.md
npm notice 1.4kB   package.json
npm notice 40.4kB  testing/proto/profile.d.ts
npm notice 171.1kB testing/proto/profile.js
npm notice 9.5kB   testing/proto/profile.proto
npm notice 466B    testing/proto/README.md
npm notice 261.1kB testing/test.pprof
npm notice === Tarball Details ===
npm notice name:          pprof-format
npm notice version:       2.0.4
npm notice filename:      pprof-format-2.0.4.tgz
npm notice package size:  289.8 kB
npm notice unpacked size: 492.7 kB
npm notice shasum:        761106f11c223c1e65933f1394fbb0690fa339e9
npm notice integrity:     sha512-bp/OKhFnojk4b[...]WmRC5lprjwNwA==
npm notice total files:   18
npm notice
pprof-format-2.0.4.tgz
```

After:
```
> npm pack
npm notice
npm notice 📦  pprof-format@2.0.4
npm notice === Tarball Contents ===
npm notice 555B    .github/ISSUE_TEMPLATE/bug_report.md
npm notice 119B    .github/ISSUE_TEMPLATE/feature_request.md
npm notice 573B    .github/workflows/ci.yml
npm notice 1.7kB   .github/workflows/codeql.yml
npm notice 582B    .github/workflows/package-size.yml
npm notice 352B    .github/workflows/pr-labels.yml
npm notice 714B    .github/workflows/release.yml
npm notice 329B    CONTRIBUTING.md
npm notice 1.1kB   LICENSE
npm notice 569B    LICENSE-3rdparty.csv
npm notice 147B    NOTICE
npm notice 2.1kB   README.md
npm notice 1.4kB   package.json
npm notice 289.8kB pprof-format-2.0.4.tgz
npm notice === Tarball Details ===
npm notice name:          pprof-format
npm notice version:       2.0.4
npm notice filename:      pprof-format-2.0.4.tgz
npm notice package size:  295.8 kB
npm notice unpacked size: 300.0 kB
npm notice shasum:        c6d7419cb4dd898f80535c6bcf359ce471e16b77
npm notice integrity:     sha512-QnJW+cTCHaRtY[...]zR5VPxnoyglaA==
npm notice total files:   14
npm notice
pprof-format-2.0.4.tgz
```