### PR TITLE
v2.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,8 @@ jobs:
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pprof-format",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Pure JavaScript pprof encoder and decoder",
   "author": "Datadog Inc. <info@datadoghq.com>",
   "license": "MIT",


### PR DESCRIPTION
* Remove download-artifact as it is not used and older version fails the release
* Upgrade checkout and setup-node actions to their latest versions