### PR TITLE
Prepare repo for releasing with OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: npm
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     permissions:
+      id-token: write # Required for OIDC
       contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm publish


### PR DESCRIPTION
**What does this PR do?**:
* Updates `release.yml` so it works well with OIDC release method.

**Motivation**:
Npm no longer allows releasing with broad tokens. It still allows releasing with granular tokens, but their lifetime is limited now. This all makes releasing while authenticating with tokens painful. OIDC provides a much better way to release the packages, and will be the preferred way going forward.

OIDC needs to be enabled for this repo in the Npm settings – this was already done. After that, publishing is rather simple, it no longer requires a token, but rather depends on GitHub proving to Npm that the release request came from a GH action as configured (we need to specify the organization, repo name, filename with the release action, and the release environment in the NPM configuration.)

**Additional Notes**:
Node.js 24 is used explicitly for releasing so we have a recent version of `npm` CLI. The token is removed from the release, the only thing required for OIDC to work from the GH side is a write permission to `id-token` in the action.

Jira: [PROF-13278]

[PROF-13278]: https://datadoghq.atlassian.net/browse/PROF-13278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ