### PR TITLE
[Security] Add 2-day minimum release age cooldown (incident-51987)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=2


### PR DESCRIPTION
## Summary

- Adds `.npmrc` with `min-release-age=2` to enforce a 2-day cooldown on npm package releases before they can be installed
- Protects against supply chain attacks by ensuring newly published or compromised package versions are not immediately consumed
- Part of the security pinning campaign for incident-51987

## Test plan

- [x] Verify `.npmrc` contains `min-release-age=2`
- [ ] Confirm `npm install` respects the cooldown setting on next dependency install

🤖 Generated with [Claude Code](https://claude.com/claude-code)