### PR TITLE
Add Dependabot config for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` configuring weekly grouped update PRs for GitHub Actions, as recommended in #36's PR description after pinning actions to SHA hashes.

## Test plan
- [ ] After merge, confirm Dependabot opens grouped weekly PRs that update both the SHA and the version comment for pinned actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)