### PR TITLE
chore(ownership): add CODEOWNERS for unowned files [SCMGMT-741]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DataDog/profiling @DataDog/dd-trace-js


### PR DESCRIPTION
## Summary

Adds CODEOWNERS entries for previously unowned files (SCMGMT-741).

## Test plan
- [ ] Review suggested owners look reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)