### PR TITLE
ci: use Node 20 for lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
     - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
       with:
-        node-version: 18
+        node-version: 20
     - run: npm ci
     - run: npm run lint


### PR DESCRIPTION
ESLint 10 and `@eslint/js` 10 use `util.styleText` which requires Node >= 20 (added in Node 20.12.0). The lint job was still pinned to Node 18, causing failures in Dependabot PRs that bump those packages.