### PR TITLE
fix: TypeScript 6 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "protobufjs-cli": "^2.5.1",
         "tap": "^21.7.4",
         "tshy": "^3.0.2",
-        "typescript": "^5.8.3"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -1187,6 +1187,20 @@
       },
       "peerDependencies": {
         "@tapjs/core": "4.5.8"
+      }
+    },
+    "node_modules/@tapjs/test/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@tapjs/typescript": {
@@ -5437,6 +5451,20 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/tshy/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/tuf-js": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
@@ -5479,9 +5507,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "protobufjs-cli": "^2.5.1",
     "tap": "^21.7.4",
     "tshy": "^3.0.2",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   },
   "tap": {
     "plugin": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,7 +288,7 @@ export class StringTable {
       // Encode strings on insertion
       this.#encodings.push(StringTable._encodeString(string))
     }
-    return this.#positions.get(string)
+    return this.#positions.get(string)!
   }
 
   _decodeString(buffer: Uint8Array) {
@@ -300,9 +300,9 @@ export class StringTable {
 
 function decode<T>(
   buffer: Uint8Array,
-  decoder: (data: DeepPartial<T>, field: number, value: Uint8Array) => void
+  decoder: (data: any, field: number, value: Uint8Array) => void
 ): DeepPartial<T> {
-  const data = {}
+  const data: any = {}
   let index = 0
 
   while (index < buffer.length) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "noImplicitAny": true,
     "preserveConstEnums": true,
     "sourceMap": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Fixes three TypeScript 6 breaking changes and bumps the TypeScript devDependency to `^6.0.3`.

## Changes

**`tsconfig.json`**: add `"types": ["node"]`
TypeScript 6 no longer auto-includes Node.js types when `@types/node` is in `node_modules`. The `Buffer` type (used in `src/index.ts`) now requires an explicit opt-in.

**`src/index.ts` — `Map.get()` assertion**
`Map.prototype.get()` returns `T | undefined`. TypeScript 6 no longer allows assigning that to `number` without an assertion, even after a preceding `.has()` call. Added `!` non-null assertion on the known-present lookup.

**`src/index.ts` — `decode()` helper typing**
The internal `decode<T>` helper passes an empty `{}` object to a decoder callback that fills it in field-by-field. The callback type was `(data: DeepPartial<T>, ...) => void`. TypeScript 6 tightened `DeepPartial<primitiveType>` inference, making it incompatible with the original type. Changed the accumulator and callback parameter to `any`, which correctly reflects the runtime semantics (it starts as `{}` and is mutated into `T`).

Closes #50