### PR TITLE
fix: remove useless post-increment of offset

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -270,7 +270,7 @@ export class StringTable {
     buffer[offset++] = 50 // (6 << 3) + kTypeLengthDelim
     offset = encodeNumber(buffer, offset, stringBuffer.length)
     if (stringBuffer.length > 0) {
-      buffer.set(stringBuffer, offset++)
+      buffer.set(stringBuffer, offset)
     }
     return buffer
   }


### PR DESCRIPTION
`offset` is incremented after `buffer.set()` in `_encodeStringFromUtf8`, but the new value is never read — the function returns `buffer` immediately after. This is a no-op in practice.

Caught by the `no-useless-assignment` rule introduced in `@eslint/js` 10 (PR #57). Fixing it in main so that PR #57 is clean after rebase.