### PR TITLE
fix: migrate non-packed repeated fields test to node:test

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -401,14 +401,14 @@ test('Protobufjs compat', async (t) => {
   })
 })
 
-tap.test('non-packed repeated fields', async (t: Test) => {
+test('non-packed repeated fields', async (t: TestContext) => {
   // Go's runtime/pprof encodes Sample.value as non-packed repeated int64 (one
   // field occurrence per value). The decoder must append rather than overwrite
   // on each occurrence.
 
   await t.test(
     'decodes Sample value from non-packed repeated int64',
-    async (t: Test) => {
+    async () => {
       // testing/non-packed-repeated.pprof has sampleType [samples/count, cpu/nanoseconds]
       // and one sample whose two values are stored as separate non-packed
       // varint fields.
@@ -416,29 +416,29 @@ tap.test('non-packed repeated fields', async (t: Test) => {
 
       const profile = Profile.decode(buf)
 
-      t.same(profile.sample[0].value, [1, 10000000])
+      assert.deepEqual(profile.sample[0].value, [1, 10000000])
     },
   )
 
   await t.test(
     'decodes Sample locationId from non-packed repeated int64',
-    async (t: Test) => {
+    async () => {
       // field 1 (locationId), wire 0: tag = (1 << 3) | 0 = 0x08
       // Two occurrences: value 5 → 08 05, value 7 → 08 07
       const sample = Sample.decode(hexToBuf('08050807'))
 
-      t.same(sample.locationId, [5, 7])
+      assert.deepEqual(sample.locationId, [5, 7])
     },
   )
 
   await t.test(
     'decodes Profile comment from non-packed repeated int64',
-    async (t: Test) => {
+    async () => {
       // field 13 (comment), wire 0: tag = (13 << 3) | 0 = 0x68
       // Two occurrences: value 3 → 68 03, value 9 → 68 09
       const profile = Profile.decode(hexToBuf('68036809'))
 
-      t.same(profile.comment, [3, 9])
+      assert.deepEqual(profile.comment, [3, 9])
     },
   )
 })


### PR DESCRIPTION
PR #45 added the non-packed repeated fields tests after PR #58 had already replaced `tap` with `node:test`. The new tests were written in the old `tap` style (`tap.test`, `t: Test`, `t.same`), leaving main with broken tests (no `tap` dependency but `tap.test()` calls).

Converts to `test`/`TestContext`/`assert.deepEqual` to match the rest of the file. Also removes the unused `t` parameter from the inner subtests since they only use `assert` directly.

Fixes CI for PR #57 (and main itself).