### PR TITLE
fix: release tag push and pin actions by SHA

### DIFF
--- a/.github/chainguard/self.github.release.push-tags.sts.yaml
+++ b/.github/chainguard/self.github.release.push-tags.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/pprof-format:environment:npm
+
+claim_pattern:
+  event_name: push
+  job_workflow_ref: DataDog/pprof-format/\.github/workflows/release\.yml@refs/heads/v[0-9]+\.x
+  ref: refs/heads/v[0-9]+\.x
+  repository: DataDog/pprof-format
+
+permissions:
+  contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,16 @@ jobs:
     environment: npm
     permissions:
       id-token: write # Required for OIDC
-      contents: write
+      contents: read
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/pprof-format
+          policy: self.github.release.push-tags
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false # drop GITHUB_TOKEN so the dd-octo-sts token is used for the tag push
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
@@ -23,7 +30,7 @@ jobs:
       - id: pkg
         run: |
           content=`cat ./package.json | tr '\n' ' '`
-          echo "::set-output name=json::$content"
+          echo "json=$content" >> $GITHUB_OUTPUT
       - run: |
           git tag v${{ fromJson(steps.pkg.outputs.json).version }}
-          git push origin v${{ fromJson(steps.pkg.outputs.json).version }}
+          git push https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com/${{ github.repository }}.git v${{ fromJson(steps.pkg.outputs.json).version }}


### PR DESCRIPTION
The release workflow's tag push was rejected by the tag ruleset because `actions/checkout` persisted GITHUB_TOKEN credentials, which took precedence over the `dd-octo-sts` token in the explicit push URL.

## Changes

- Add `DataDog/dd-octo-sts-action` step to obtain a token with tag-push permission
- Add `.github/chainguard/self.github.release.push-tags.sts.yaml` policy file
- Set `persist-credentials: false` on checkout so the GITHUB_TOKEN doesn't shadow the octo-sts token
- Downgrade `contents` permission from `write` to `read`
- Fix deprecated `::set-output` syntax to use `$GITHUB_OUTPUT`

Mirrors the fix applied in DataDog/pprof-nodejs@1417470e2c51046d4e7ff48ca6f10032ff91816f