### PR TITLE
Fix CI type error in assertHas message parameter

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -50,7 +50,7 @@ function hasMatch(found: any, wanted: any): boolean {
   return found == wanted
 }
 
-function assertHas(found: any, wanted: any, message?: string) {
+function assertHas(found: any, wanted: any, message: string) {
   assert.ok(hasMatch(found, wanted), message)
 }
 


### PR DESCRIPTION
## Summary
- `assertHas`'s optional `message?: string` parameter allowed `undefined`, which doesn't satisfy either overload of `assert.ok`, breaking the `build:test` TypeScript compile in CI.
- Every call site already passes an explicit message, so the parameter is made required instead of adding a placeholder default.

## Test plan
- [x] `npm test` passes locally (76/76)