### PR TITLE
perf: remove accidentally quadratic work

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,14 +48,14 @@ function getValue(mode: number, buffer: Uint8Array) {
     case kTypeVarInt:
       for (let i = 0; i < buffer.length; i++) {
         if (!(buffer[i] & 0b10000000)) {
-          return makeValue(buffer.slice(0, i + 1))
+          return makeValue(buffer.subarray(0, i + 1))
         }
       }
       return makeValue(buffer)
     case kTypeLengthDelim: {
       const offset = countNumberBytes(buffer)
       const size = decodeNumber(buffer)
-      return makeValue(buffer.slice(offset, Number(size) + offset), offset)
+      return makeValue(buffer.subarray(offset, Number(size) + offset), offset)
     }
     default:
       throw new Error(`Unrecognized value type: ${mode}`)
@@ -118,7 +118,7 @@ function decodeNumbers(buffer: Uint8Array): Array<Numeric> {
 
   for (let i = 0; i < buffer.length; i++) {
     if ((buffer[i] & 0b10000000) === 0) {
-      values.push(decodeNumber(buffer.slice(start, i + 1)))
+      values.push(decodeNumber(buffer.subarray(start, i + 1)))
       start = i + 1
     }
   }
@@ -320,7 +320,7 @@ function decode<T>(
     const mode = buffer[index] & 0b111
     index++
 
-    const { offset, value } = getValue(mode, buffer.slice(index))
+    const { offset, value } = getValue(mode, buffer.subarray(index))
     index += value.length + offset
 
     decoder(data, field, value)


### PR DESCRIPTION
`decode()` called `buffer.slice(index)` for every field, copying the entire remaining buffer each time. For the top-level `Profile` message that re-copies ~all of the input per field, making decoding quadratic in message size. `subarray()` returns a zero-copy view instead. Decoding only reads from the view, and `_decodeString` copies the bytes it retains, so no buffer is held alive beyond decoding.

[profiler-md](https://github.com/TomerAberbach/profiler-md) diff decoding a [large pprof file](https://github.com/TomerAberbach/profiler-md/blob/main/examples/input/julia.pprof-jl.cpu.base.pprof) 3 times, before vs after:

# CPU profile diff

Took 38.58s → 492.9ms (-38.09s, -98.7%) over 30,438 samples → 392 samples (1.3ms per sample).

| Category          | Change |   Delta |             % |             Time |      Samples |
| ----------------- | -----: | ------: | ------------: | ---------------: | -----------: |
| ours              | -98.5% | -24.22s | 63.8% → 76.1% | 24.60s → 375.3ms | 19,381 → 307 |
| garbage collector | -99.3% | -13.85s | 36.1% → 19.0% |  13.94s → 93.6ms |  11,037 → 72 |
| program           | -34.8% |  -8.7ms |   0.1% → 3.3% |  25.0ms → 16.3ms |       11 → 7 |
| stdlib            | -33.2% |  -3.8ms |   0.0% → 1.5% |   11.4ms → 7.6ms |        9 → 6 |

## Hottest functions

### Self time

#### Regressions

Functions with the largest increase in time spent directly in the function body, excluding callees.

|  Change |  Delta |            % |              Time |  Samples | Function          | Location                                                                                                                           |
| ------: | -----: | -----------: | ----------------: | -------: | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
|     new | +1.3ms |  0.0% → 0.3% |       0ms → 1.3ms |    0 → 1 | `(anonymous)`     | ../../../../private/tmp/claude-501/-Users-tomer-Desktop-pprof-format/d5b1df43-574f-40fb-b6c1-407c30f1a82c/scratchpad/bench.mjs:1:1 |
|     new | +1.3ms |  0.0% → 0.3% |       0ms → 1.3ms |    0 → 1 | `pushAll`         | dist/esm/index.js:125:17                                                                                                           |
|     new | +1.3ms |  0.0% → 0.3% |       0ms → 1.3ms |    0 → 1 | `TextDecoder`     | node:internal/encoding:431:14                                                                                                      |
|   +0.4% | +0.5ms | 0.3% → 25.2% | 123.8ms → 124.3ms | 99 → 100 | `decodeBigNumber` | dist/esm/index.js:30:25                                                                                                            |
|   +3.9% | +0.2ms |  0.0% → 1.1% |     5.3ms → 5.5ms |    5 → 6 | `decodeNumber`    | dist/esm/index.js:94:22                                                                                                            |
| +102.4% |   +0ms |         0.0% |       0ms → 0.1ms |        1 | `encodeNumber`    | dist/esm/index.js:197:22                                                                                                           |

#### Progressions

Functions with the largest decrease in time spent directly in the function body, excluding callees.

|  Change |    Delta |             % |             Time |     Samples | Function                | Location                 |
| ------: | -------: | ------------: | ---------------: | ----------: | ----------------------- | ------------------------ |
|  -99.3% |  -13.85s | 36.1% → 19.0% |  13.94s → 93.6ms | 11,037 → 72 | `(garbage collector)`   | `<unknown>`              |
|  -83.9% | -246.9ms |   0.8% → 9.6% | 294.3ms → 47.5ms |    233 → 38 | `getValue`              | dist/esm/index.js:43:18  |
|  -24.5% |  -31.5ms |  0.3% → 19.7% | 128.6ms → 97.0ms |    101 → 78 | `decodeNumbers`         | dist/esm/index.js:107:23 |
|  -34.8% |   -8.7ms |   0.1% → 3.3% |  25.0ms → 16.3ms |      11 → 7 | `(program)`             | `<unknown>`              |
|  -81.4% |   -8.2ms |   0.0% → 0.4% |   10.1ms → 1.9ms |       8 → 2 | `Profile`               | dist/esm/index.js:752:16 |
| removed |   -5.0ms |          0.0% |      5.0ms → 0ms |       4 → 0 | `push`                  | dist/esm/index.js:118:14 |
| removed |   -2.5ms |          0.0% |      2.5ms → 0ms |       2 → 0 | `Sample`                | dist/esm/index.js:395:16 |
| removed |   -2.5ms |          0.0% |      2.5ms → 0ms |       2 → 0 | `create`                | dist/esm/index.js:331:18 |
| removed |   -1.3ms |          0.0% |      1.3ms → 0ms |       1 → 0 | `Location`              | dist/esm/index.js:612:16 |
| removed |   -1.3ms |          0.0% |      1.3ms → 0ms |       1 → 0 | `_encodeStringFromUtf8` | dist/esm/index.js:243:33 |
| removed |   -1.2ms |          0.0% |      1.2ms → 0ms |       1 → 0 | `consoleCall`           | `<unknown>`              |
| removed |   -0.8ms |          0.0% |      0.8ms → 0ms |       1 → 0 | `_decodeString`         | dist/esm/index.js:267:18 |

### Total time

#### Regressions

Functions with the largest increase in total time spent in the function and all its callees.

|  Change |  Delta |            % |              Time |  Samples | Function          | Location                      |
| ------: | -----: | -----------: | ----------------: | -------: | ----------------- | ----------------------------- |
|     new | +1.3ms |  0.0% → 0.3% |       0ms → 1.3ms |    0 → 1 | `pushAll`         | dist/esm/index.js:125:17      |
|     new | +1.3ms |  0.0% → 0.3% |       0ms → 1.3ms |    0 → 1 | `TextDecoder`     | node:internal/encoding:431:14 |
|  +60.1% | +0.6ms |  0.0% → 0.3% |     1.0ms → 1.7ms |    1 → 2 | `decode`          | dist/esm/index.js:747:18      |
|   +0.4% | +0.5ms | 0.3% → 25.2% | 123.8ms → 124.3ms | 99 → 100 | `decodeBigNumber` | dist/esm/index.js:30:25       |
| +102.4% |   +0ms |         0.0% |       0ms → 0.1ms |        1 | `encodeNumber`    | dist/esm/index.js:197:22      |

#### Progressions

Functions with the largest decrease in total time spent in the function and all its callees.

|  Change |    Delta |             % |              Time |      Samples | Function                | Location                                                                                                                           |
| ------: | -------: | ------------: | ----------------: | -----------: | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
|  -98.5% |  -24.23s | 63.8% → 75.9% |  24.60s → 374.0ms | 19,385 → 306 | `(anonymous)`           | ../../../../private/tmp/claude-501/-Users-tomer-Desktop-pprof-format/d5b1df43-574f-40fb-b6c1-407c30f1a82c/scratchpad/bench.mjs:1:1 |
|  -99.3% |  -13.85s | 36.1% → 19.0% |   13.94s → 93.6ms |  11,037 → 72 | `(garbage collector)`   | `<unknown>`                                                                                                                        |
|  -83.9% | -246.9ms |   0.8% → 9.6% |  294.3ms → 47.5ms |     233 → 38 | `getValue`              | dist/esm/index.js:43:18                                                                                                            |
|   -8.7% |  -20.0ms |  0.6% → 42.6% | 229.7ms → 209.8ms |    181 → 168 | `decodeNumbers`         | dist/esm/index.js:107:23                                                                                                           |
|  -34.8% |   -8.7ms |   0.1% → 3.3% |   25.0ms → 16.3ms |       11 → 7 | `(program)`             | `<unknown>`                                                                                                                        |
|  -81.4% |   -8.2ms |   0.0% → 0.4% |    10.1ms → 1.9ms |        8 → 2 | `Profile`               | dist/esm/index.js:752:16                                                                                                           |
| removed |   -5.0ms |          0.0% |       5.0ms → 0ms |        4 → 0 | `push`                  | dist/esm/index.js:118:14                                                                                                           |
|  -90.0% |   -3.8ms |   0.0% → 0.1% |     4.2ms → 0.4ms |        5 → 1 | `decodeValue`           | dist/esm/index.js:728:23                                                                                                           |
| removed |   -3.8ms |          0.0% |       3.8ms → 0ms |        3 → 0 | `Sample`                | dist/esm/index.js:395:16                                                                                                           |
|   -2.5% |   -3.2ms |  0.3% → 25.6% | 129.2ms → 126.0ms |    104 → 103 | `decodeNumber`          | dist/esm/index.js:94:22                                                                                                            |
|  -67.4% |   -2.5ms |   0.0% → 0.2% |     3.7ms → 1.2ms |        3 → 1 | `consoleCall`           | `<unknown>`                                                                                                                        |
| removed |   -2.5ms |          0.0% |       2.5ms → 0ms |        2 → 0 | `create`                | dist/esm/index.js:331:18                                                                                                           |
| removed |   -1.3ms |          0.0% |       1.3ms → 0ms |        1 → 0 | `Location`              | dist/esm/index.js:612:16                                                                                                           |
|  -93.6% |   -1.2ms |          0.0% |     1.3ms → 0.1ms |        2 → 1 | `_encodeStringFromUtf8` | dist/esm/index.js:243:33                                                                                                           |
|  -37.3% |   -0.8ms |   0.0% → 0.3% |     2.1ms → 1.3ms |        3 → 2 | `_decodeString`         | dist/esm/index.js:267:18                                                                                                           |