### PR TITLE
feat: add column field to Line message

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -154,12 +154,14 @@ test('Label', async (t) => {
 
 const lineData = {
   functionId: 1234,
-  line: 5678
+  line: 5678,
+  column: 90
 }
 
 const lineEncodings = [
   { field: 'functionId', value: '08d209' },
   { field: 'line', value: '10ae2c' },
+  { field: 'column', value: '185a' },
 ]
 
 test('Line', async (t) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -701,11 +701,13 @@ export class Mapping {
 export type LineInput = {
   functionId?: Numeric
   line?: Numeric
+  column?: Numeric
 }
 
 export class Line {
   functionId: Numeric
   line: Numeric
+  column: Numeric
 
   static create(data: LineInput): Line {
     return data instanceof Line ? data : new Line(data)
@@ -714,12 +716,14 @@ export class Line {
   constructor(data: LineInput) {
     this.functionId = data.functionId || 0
     this.line = data.line || 0
+    this.column = data.column || 0
   }
 
   get length() {
     let total = 0
     total += measureNumberField(this.functionId)
     total += measureNumberField(this.line)
+    total += measureNumberField(this.column)
     return total
   }
 
@@ -732,6 +736,11 @@ export class Line {
     if (this.line) {
       buffer[offset++] = 16 // (2 << 3) + kTypeVarInt
       offset = encodeNumber(buffer, offset, this.line)
+    }
+
+    if (this.column) {
+      buffer[offset++] = 24 // (3 << 3) + kTypeVarInt
+      offset = encodeNumber(buffer, offset, this.column)
     }
 
     return offset
@@ -749,6 +758,9 @@ export class Line {
         break
       case 2:
         data.line = decodeNumber(buffer)
+        break
+      case 3:
+        data.column = decodeNumber(buffer)
         break
     }
   }

--- a/testing/proto/profile.d.ts
+++ b/testing/proto/profile.d.ts
@@ -788,6 +788,9 @@ export namespace perftools {
 
             /** Line line */
             line?: (number|Long|null);
+
+            /** Line column */
+            column?: (number|Long|null);
         }
 
         /** Represents a Line. */
@@ -804,6 +807,9 @@ export namespace perftools {
 
             /** Line line. */
             public line: (number|Long);
+
+            /** Line column. */
+            public column: (number|Long);
 
             /**
              * Creates a new Line instance using the specified properties.

--- a/testing/proto/profile.js
+++ b/testing/proto/profile.js
@@ -2562,6 +2562,7 @@ $root.perftools = (function() {
              * @interface ILine
              * @property {number|Long|null} [functionId] Line functionId
              * @property {number|Long|null} [line] Line line
+             * @property {number|Long|null} [column] Line column
              */
 
             /**
@@ -2596,6 +2597,14 @@ $root.perftools = (function() {
             Line.prototype.line = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
             /**
+             * Line column.
+             * @member {number|Long} column
+             * @memberof perftools.profiles.Line
+             * @instance
+             */
+            Line.prototype.column = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+            /**
              * Creates a new Line instance using the specified properties.
              * @function create
              * @memberof perftools.profiles.Line
@@ -2623,6 +2632,8 @@ $root.perftools = (function() {
                     writer.uint32(/* id 1, wireType 0 =*/8).uint64(message.functionId);
                 if (message.line != null && Object.hasOwnProperty.call(message, "line"))
                     writer.uint32(/* id 2, wireType 0 =*/16).int64(message.line);
+                if (message.column != null && Object.hasOwnProperty.call(message, "column"))
+                    writer.uint32(/* id 3, wireType 0 =*/24).int64(message.column);
                 return writer;
             };
 
@@ -2663,6 +2674,10 @@ $root.perftools = (function() {
                         }
                     case 2: {
                             message.line = reader.int64();
+                            break;
+                        }
+                    case 3: {
+                            message.column = reader.int64();
                             break;
                         }
                     default:
@@ -2706,6 +2721,9 @@ $root.perftools = (function() {
                 if (message.line != null && message.hasOwnProperty("line"))
                     if (!$util.isInteger(message.line) && !(message.line && $util.isInteger(message.line.low) && $util.isInteger(message.line.high)))
                         return "line: integer|Long expected";
+                if (message.column != null && message.hasOwnProperty("column"))
+                    if (!$util.isInteger(message.column) && !(message.column && $util.isInteger(message.column.low) && $util.isInteger(message.column.high)))
+                        return "column: integer|Long expected";
                 return null;
             };
 
@@ -2739,6 +2757,15 @@ $root.perftools = (function() {
                         message.line = object.line;
                     else if (typeof object.line === "object")
                         message.line = new $util.LongBits(object.line.low >>> 0, object.line.high >>> 0).toNumber();
+                if (object.column != null)
+                    if ($util.Long)
+                        (message.column = $util.Long.fromValue(object.column)).unsigned = false;
+                    else if (typeof object.column === "string")
+                        message.column = parseInt(object.column, 10);
+                    else if (typeof object.column === "number")
+                        message.column = object.column;
+                    else if (typeof object.column === "object")
+                        message.column = new $util.LongBits(object.column.low >>> 0, object.column.high >>> 0).toNumber();
                 return message;
             };
 
@@ -2766,6 +2793,11 @@ $root.perftools = (function() {
                         object.line = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                     } else
                         object.line = options.longs === String ? "0" : 0;
+                    if ($util.Long) {
+                        var long = new $util.Long(0, 0, false);
+                        object.column = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                    } else
+                        object.column = options.longs === String ? "0" : 0;
                 }
                 if (message.functionId != null && message.hasOwnProperty("functionId"))
                     if (typeof message.functionId === "number")
@@ -2777,6 +2809,11 @@ $root.perftools = (function() {
                         object.line = options.longs === String ? String(message.line) : message.line;
                     else
                         object.line = options.longs === String ? $util.Long.prototype.toString.call(message.line) : options.longs === Number ? new $util.LongBits(message.line.low >>> 0, message.line.high >>> 0).toNumber() : message.line;
+                if (message.column != null && message.hasOwnProperty("column"))
+                    if (typeof message.column === "number")
+                        object.column = options.longs === String ? String(message.column) : message.column;
+                    else
+                        object.column = options.longs === String ? $util.Long.prototype.toString.call(message.column) : options.longs === Number ? new $util.LongBits(message.column.low >>> 0, message.column.high >>> 0).toNumber() : message.column;
                 return object;
             };
 

--- a/testing/proto/profile.proto
+++ b/testing/proto/profile.proto
@@ -205,6 +205,8 @@ message Line {
   uint64 function_id = 1;
   // Line number in source code.
   int64 line = 2;
+  // Column number in source code.
+  int64 column = 3;
 }
 
 message Function {


### PR DESCRIPTION
## What

Adds the optional `column` field (field 3) to the pprof `Line` message: `LineInput` type, constructor, `length`, encode (varint, tag `0x18`), and decode — mirroring the existing `line` (field 2) handling.

The [pprof spec](https://github.com/google/pprof/blob/main/proto/profile.proto) `Line` message carries `column` as field 3, and current `google/pprof` tooling reads and prints it (`go tool pprof` renders `file:line:column`). This library did not encode or decode it, so any column set on a `Line` was silently dropped on the wire.

The reason we don't have it here is that it's a fairly recent addition in https://github.com/google/pprof/pull/818 and was only merged into the spec in January 2024.

## Changes

- `src/index.ts` — `column` on the `Line` message (type, ctor, `length`, encode, decode).
- `testing/proto/profile.proto` — add `int64 column = 3;` to the reference `Line` so the protobuf.js interop test round-trips the field; regenerated `profile.js` / `profile.d.ts` were hand-edited to add **only** the column field in the existing codegen style (avoiding the unrelated churn a full `npm run proto` produces with the current protobuf.js version).
- `src/index.test.ts` — extend the `Line` encode/decode/construct case with a `column` value.

## Testing

`npm test` — **76/76 pass**, including the protobuf.js interop round-trip with the new field.