### PR TITLE
feat: add doc_url field to Profile message

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -319,6 +319,27 @@ test('Profile', async (t) => {
   })
 })
 
+test('Profile docUrl', async (t) => {
+  // doc_url is field 15, an int64 index into the string table: tag byte
+  // (15 << 3) | kTypeVarInt = 0x78, followed by the varint value.
+  await t.test('encodes docUrl', () => {
+    // emptyTableToken excludes the string table so only docUrl is encoded.
+    const profile = new Profile({
+      stringTable: new StringTable(emptyTableToken),
+      docUrl: 5,
+    })
+    assert.strictEqual(bufToHex(profile.encode()), '7805')
+  })
+
+  await t.test('decodes docUrl', () => {
+    assert.strictEqual(Number(Profile.decode(hexToBuf('7805')).docUrl), 5)
+  })
+
+  await t.test('defaults docUrl to 0 when absent', () => {
+    assert.strictEqual(Number(new Profile().docUrl), 0)
+  })
+})
+
 function encodeStringTable(strings: StringTable) {
   return strings.strings.map(s => {
     const buf = new TextEncoder().encode(s)

--- a/src/index.ts
+++ b/src/index.ts
@@ -970,6 +970,7 @@ export type ProfileInput = {
   period?: Numeric
   comment?: Array<Numeric>
   defaultSampleType?: Numeric
+  docUrl?: Numeric
 }
 
 export class Profile {
@@ -987,6 +988,7 @@ export class Profile {
   period: Numeric
   comment: Array<Numeric>
   defaultSampleType: Numeric
+  docUrl: Numeric
 
   constructor(data: ProfileInput = {}) {
     this.sampleType = (data.sampleType || []).map(ValueType.create)
@@ -1003,6 +1005,7 @@ export class Profile {
     this.period = data.period || 0
     this.comment = data.comment || []
     this.defaultSampleType = data.defaultSampleType || 0
+    this.docUrl = data.docUrl || 0
   }
 
   get length() {
@@ -1021,6 +1024,7 @@ export class Profile {
     total += measureNumberField(this.period)
     total += measureNumberArrayField(this.comment)
     total += measureNumberField(this.defaultSampleType)
+    total += measureNumberField(this.docUrl)
     return total
   }
 
@@ -1112,6 +1116,11 @@ export class Profile {
     if (this.defaultSampleType) {
       buffer[offset++] = 112 // (14 << 3) + kTypeVarInt
       offset = encodeNumber(buffer, offset, this.defaultSampleType)
+    }
+
+    if (this.docUrl) {
+      buffer[offset++] = 120 // (15 << 3) + kTypeVarInt
+      offset = encodeNumber(buffer, offset, this.docUrl)
     }
 
     return offset
@@ -1208,6 +1217,9 @@ export class Profile {
         break
       case 14:
         data.defaultSampleType = decodeNumber(buffer)
+        break
+      case 15:
+        data.docUrl = decodeNumber(buffer)
         break
     }
   }

--- a/testing/proto/profile.d.ts
+++ b/testing/proto/profile.d.ts
@@ -50,6 +50,9 @@ export namespace perftools {
 
             /** Profile defaultSampleType */
             defaultSampleType?: (number|Long|null);
+
+            /** Profile docUrl */
+            docUrl?: (number|Long|null);
         }
 
         /** Represents a Profile. */
@@ -102,6 +105,9 @@ export namespace perftools {
 
             /** Profile defaultSampleType. */
             public defaultSampleType: (number|Long);
+
+            /** Profile docUrl. */
+            public docUrl: (number|Long);
 
             /**
              * Creates a new Profile instance using the specified properties.

--- a/testing/proto/profile.js
+++ b/testing/proto/profile.js
@@ -47,6 +47,7 @@ $root.perftools = (function() {
              * @property {number|Long|null} [period] Profile period
              * @property {Array.<number|Long>|null} [comment] Profile comment
              * @property {number|Long|null} [defaultSampleType] Profile defaultSampleType
+             * @property {number|Long|null} [docUrl] Profile docUrl
              */
 
             /**
@@ -184,6 +185,14 @@ $root.perftools = (function() {
             Profile.prototype.defaultSampleType = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
             /**
+             * Profile docUrl.
+             * @member {number|Long} docUrl
+             * @memberof perftools.profiles.Profile
+             * @instance
+             */
+            Profile.prototype.docUrl = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+            /**
              * Creates a new Profile instance using the specified properties.
              * @function create
              * @memberof perftools.profiles.Profile
@@ -245,6 +254,8 @@ $root.perftools = (function() {
                 }
                 if (message.defaultSampleType != null && Object.hasOwnProperty.call(message, "defaultSampleType"))
                     writer.uint32(/* id 14, wireType 0 =*/112).int64(message.defaultSampleType);
+                if (message.docUrl != null && Object.hasOwnProperty.call(message, "docUrl"))
+                    writer.uint32(/* id 15, wireType 0 =*/120).int64(message.docUrl);
                 return writer;
             };
 
@@ -352,6 +363,10 @@ $root.perftools = (function() {
                         }
                     case 14: {
                             message.defaultSampleType = reader.int64();
+                            break;
+                        }
+                    case 15: {
+                            message.docUrl = reader.int64();
                             break;
                         }
                     default:
@@ -471,6 +486,9 @@ $root.perftools = (function() {
                 if (message.defaultSampleType != null && message.hasOwnProperty("defaultSampleType"))
                     if (!$util.isInteger(message.defaultSampleType) && !(message.defaultSampleType && $util.isInteger(message.defaultSampleType.low) && $util.isInteger(message.defaultSampleType.high)))
                         return "defaultSampleType: integer|Long expected";
+                if (message.docUrl != null && message.hasOwnProperty("docUrl"))
+                    if (!$util.isInteger(message.docUrl) && !(message.docUrl && $util.isInteger(message.docUrl.low) && $util.isInteger(message.docUrl.high)))
+                        return "docUrl: integer|Long expected";
                 return null;
             };
 
@@ -616,6 +634,15 @@ $root.perftools = (function() {
                         message.defaultSampleType = object.defaultSampleType;
                     else if (typeof object.defaultSampleType === "object")
                         message.defaultSampleType = new $util.LongBits(object.defaultSampleType.low >>> 0, object.defaultSampleType.high >>> 0).toNumber();
+                if (object.docUrl != null)
+                    if ($util.Long)
+                        (message.docUrl = $util.Long.fromValue(object.docUrl)).unsigned = false;
+                    else if (typeof object.docUrl === "string")
+                        message.docUrl = parseInt(object.docUrl, 10);
+                    else if (typeof object.docUrl === "number")
+                        message.docUrl = object.docUrl;
+                    else if (typeof object.docUrl === "object")
+                        message.docUrl = new $util.LongBits(object.docUrl.low >>> 0, object.docUrl.high >>> 0).toNumber();
                 return message;
             };
 
@@ -673,6 +700,11 @@ $root.perftools = (function() {
                         object.defaultSampleType = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                     } else
                         object.defaultSampleType = options.longs === String ? "0" : 0;
+                    if ($util.Long) {
+                        var long = new $util.Long(0, 0, false);
+                        object.docUrl = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                    } else
+                        object.docUrl = options.longs === String ? "0" : 0;
                 }
                 if (message.sampleType && message.sampleType.length) {
                     object.sampleType = [];
@@ -744,6 +776,11 @@ $root.perftools = (function() {
                         object.defaultSampleType = options.longs === String ? String(message.defaultSampleType) : message.defaultSampleType;
                     else
                         object.defaultSampleType = options.longs === String ? $util.Long.prototype.toString.call(message.defaultSampleType) : options.longs === Number ? new $util.LongBits(message.defaultSampleType.low >>> 0, message.defaultSampleType.high >>> 0).toNumber() : message.defaultSampleType;
+                if (message.docUrl != null && message.hasOwnProperty("docUrl"))
+                    if (typeof message.docUrl === "number")
+                        object.docUrl = options.longs === String ? String(message.docUrl) : message.docUrl;
+                    else
+                        object.docUrl = options.longs === String ? $util.Long.prototype.toString.call(message.docUrl) : options.longs === Number ? new $util.LongBits(message.docUrl.low >>> 0, message.docUrl.high >>> 0).toNumber() : message.docUrl;
                 return object;
             };
 

--- a/testing/proto/profile.proto
+++ b/testing/proto/profile.proto
@@ -93,6 +93,8 @@ message Profile {
   // Index into the string table of the type of the preferred sample
   // value. If unset, clients should default to the last sample value.
   int64 default_sample_type = 14;
+  // Documentation link for this profile. Index into string table.
+  int64 doc_url = 15;
 }
 
 // ValueType describes the semantics and measurement units of a value.


### PR DESCRIPTION
## What

Adds the `doc_url` field (field 15, an `int64` index into the string table) to the pprof `Profile` message: `ProfileInput` type, constructor, `length`, encode (varint, tag `0x78`), and decode — mirroring the existing `defaultSampleType` field.

The pprof spec's `Profile` carries `doc_url` as a link to documentation for the profile; this library didn't encode or decode it, so a `doc_url` set on a profile was silently dropped on the wire.

## Changes

- `src/index.ts` — `docUrl` on the `Profile` message.
- `testing/proto/profile.proto` — add `int64 doc_url = 15;` so the protobuf.js interop test round-trips the field; `profile.js` / `profile.d.ts` were hand-edited to add only `doc_url` in the existing codegen style (avoiding the unrelated churn a full `npm run proto` produces with the current protobuf.js version).
- `src/index.test.ts` — encode/decode/default tests for `Profile.docUrl`.

## Testing

`npm test` — **80/80 pass**, including the protobuf.js interop round-trip.

## Context

Follows #80 (which added `Line.column`). Together these sync pprof-format with the current pprof spec so a release can be cut, after which `pprof-nodejs` can adopt both (emitting a real `Line.column` for server-side unminification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)