### PR TITLE
chore: ignore TypeScript major-version bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
     # Check the npm registry for updates once every week on a weekday
     schedule:
       interval: "weekly"
+    ignore:
+      # TypeScript 7 (the native port) is not yet supported by typescript-eslint,
+      # so major bumps break the lint job (and dependency resolution in CI).
+      # See https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      # Re-enable once typescript-eslint ships TS >=7 support.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     versioning-strategy: "increase"
     labels:
       - dependabot


### PR DESCRIPTION
## What

Adds a dependabot `ignore` rule for TypeScript **major-version** updates.

## Why

Dependabot #76 tried to bump `typescript` from 6.0.3 → 7.0.2. TypeScript 7 is the new native (Go) port, and it is **not yet supported by `typescript-eslint`**, which this repo's lint uses (`@typescript-eslint/parser` + `@typescript-eslint/eslint-plugin`). In CI this shows up as both a dependency-resolution failure and a lint failure — the `@typescript-eslint/*` peer range caps `typescript` below `6.1.0`:

```
npm error ERESOLVE could not resolve
npm error While resolving: @typescript-eslint/eslint-plugin@8.64.0
npm error Found: typescript@7.0.2
```

Support for TS ≥7 is tracked upstream but not yet shipped:
https://github.com/typescript-eslint/typescript-eslint/issues/10940

Until that lands, major `typescript` bumps can't pass CI, so this rule stops dependabot from repeatedly opening them. Minor/patch bumps within TS 6 are unaffected.

Mirrors DataDog/pprof-nodejs#380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)