### PR TITLE
v2.3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
     # Check the npm registry for updates once every week on a weekday
     schedule:
       interval: "weekly"
+    ignore:
+      # TypeScript 7 (the native port) is not yet supported by typescript-eslint,
+      # so major bumps break the lint job (and dependency resolution in CI).
+      # See https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      # Re-enable once typescript-eslint ships TS >=7 support.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     versioning-strategy: "increase"
     labels:
       - dependabot

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "@typescript-eslint/eslint-plugin": "^8.63.0",
         "@typescript-eslint/parser": "^8.37.0",
         "eslint": "^10.7.0",
-        "protobufjs": "^8.7.0",
-        "protobufjs-cli": "^2.6.0",
+        "protobufjs": "^8.7.1",
+        "protobufjs-cli": "^2.6.1",
         "tshy": "^4.1.3",
         "typescript": "^6.0.3"
       }
@@ -865,26 +865,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -979,68 +959,25 @@
       }
     },
     "node_modules/escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
         "esgenerate": "bin/esgenerate.js"
       },
       "engines": {
-        "node": ">=4.0"
+        "node": ">=6.0"
       },
       "optionalDependencies": {
         "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/eslint": {
@@ -1419,16 +1356,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2045,19 +1972,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/protobufjs": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.0.tgz",
-      "integrity": "sha512-uu52JNxLh3vsL7tXU/h0gDaywufvuUCTbGSi0NKQKBZ2ZopkmrWQJSQO/EFqzu/5YhiwgVM8rq/a/iVpx4eZ0g==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
+      "integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2068,14 +1986,13 @@
       }
     },
     "node_modules/protobufjs-cli": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-2.6.0.tgz",
-      "integrity": "sha512-ad4OuOQvCGO92amxWbqPy02p6JjmM97SP8mHz35PYl2tjYIsaeUOyizpXy8MDKxPwQ8u0wzrNzcswKyq12JIBg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-2.6.1.tgz",
+      "integrity": "sha512-ty8A5JKY/mRTlV/eW7bRoUmOxgzBL66CIBDv7wq8rQUady60rwPwAgqqumcy+oxIkUV6wWTAcxsZjLZKwNsFog==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "chalk": "^4.0.0",
-        "escodegen": "^1.13.0",
+        "escodegen": "^2.0.0",
         "espree": "^9.6.1",
         "estraverse": "^5.1.0",
         "glob": "^8.1.0",
@@ -2092,40 +2009,7 @@
         "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "protobufjs": "^8.7.0"
-      }
-    },
-    "node_modules/protobufjs-cli/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/protobufjs-cli/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+        "protobufjs": "^8.7.1"
       }
     },
     "node_modules/protobufjs-cli/node_modules/eslint-visitor-keys": {
@@ -2363,19 +2247,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/sync-content": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/sync-content/-/sync-content-2.0.4.tgz",
@@ -2464,19 +2335,6 @@
       },
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@eslint/eslintrc": "^3.3.6",
         "@eslint/js": "^10.0.1",
         "@types/node": "^26.1.1",
-        "@typescript-eslint/eslint-plugin": "^8.63.0",
+        "@typescript-eslint/eslint-plugin": "^8.64.0",
         "@typescript-eslint/parser": "^8.37.0",
         "eslint": "^10.7.0",
         "protobufjs": "^8.7.1",
@@ -383,17 +383,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
-      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
+      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/type-utils": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/type-utils": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -406,7 +406,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.63.0",
+        "@typescript-eslint/parser": "^8.64.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -422,16 +422,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
-      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
+      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -447,14 +447,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
-      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
+      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.63.0",
-        "@typescript-eslint/types": "^8.63.0",
+        "@typescript-eslint/tsconfig-utils": "^8.64.0",
+        "@typescript-eslint/types": "^8.64.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -469,14 +469,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
-      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
+      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0"
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
-      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
+      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -504,15 +504,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
-      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
+      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -529,9 +529,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
-      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
+      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -543,16 +543,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
-      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
+      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.63.0",
-        "@typescript-eslint/tsconfig-utils": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/project-service": "8.64.0",
+        "@typescript-eslint/tsconfig-utils": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -571,16 +571,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
-      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
+      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0"
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -595,13 +595,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
-      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
+      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/types": "8.64.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pprof-format",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pprof-format",
-      "version": "2.2.3",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@eslint/eslintrc": "^3.3.6",
         "@eslint/js": "^10.0.1",
         "@types/node": "^26.1.1",
-        "@typescript-eslint/eslint-plugin": "^8.64.0",
+        "@typescript-eslint/eslint-plugin": "^8.65.0",
         "@typescript-eslint/parser": "^8.37.0",
         "eslint": "^10.7.0",
         "protobufjs": "^8.7.1",
@@ -383,17 +383,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
-      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/type-utils": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -406,7 +406,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.64.0",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -422,16 +422,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
-      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -447,14 +447,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
-      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.64.0",
-        "@typescript-eslint/types": "^8.64.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -469,14 +469,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
-      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
-      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -504,15 +504,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
-      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -529,9 +529,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
-      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -543,16 +543,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
-      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.64.0",
-        "@typescript-eslint/tsconfig-utils": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -571,16 +571,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
-      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -595,13 +595,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
-      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.37.0",
     "eslint": "^10.7.0",
-    "protobufjs": "^8.7.0",
-    "protobufjs-cli": "^2.6.0",
+    "protobufjs": "^8.7.1",
+    "protobufjs-cli": "^2.6.1",
     "tshy": "^4.1.3",
     "typescript": "^6.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@eslint/eslintrc": "^3.3.6",
     "@eslint/js": "^10.0.1",
     "@types/node": "^26.1.1",
-    "@typescript-eslint/eslint-plugin": "^8.63.0",
+    "@typescript-eslint/eslint-plugin": "^8.64.0",
     "@typescript-eslint/parser": "^8.37.0",
     "eslint": "^10.7.0",
     "protobufjs": "^8.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pprof-format",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "Pure JavaScript pprof encoder and decoder",
   "author": "Datadog Inc. <info@datadoghq.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@eslint/eslintrc": "^3.3.6",
     "@eslint/js": "^10.0.1",
     "@types/node": "^26.1.1",
-    "@typescript-eslint/eslint-plugin": "^8.64.0",
+    "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.37.0",
     "eslint": "^10.7.0",
     "protobufjs": "^8.7.1",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -154,12 +154,14 @@ test('Label', async (t) => {
 
 const lineData = {
   functionId: 1234,
-  line: 5678
+  line: 5678,
+  column: 90
 }
 
 const lineEncodings = [
   { field: 'functionId', value: '08d209' },
   { field: 'line', value: '10ae2c' },
+  { field: 'column', value: '185a' },
 ]
 
 test('Line', async (t) => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -319,6 +319,27 @@ test('Profile', async (t) => {
   })
 })
 
+test('Profile docUrl', async (t) => {
+  // doc_url is field 15, an int64 index into the string table: tag byte
+  // (15 << 3) | kTypeVarInt = 0x78, followed by the varint value.
+  await t.test('encodes docUrl', () => {
+    // emptyTableToken excludes the string table so only docUrl is encoded.
+    const profile = new Profile({
+      stringTable: new StringTable(emptyTableToken),
+      docUrl: 5,
+    })
+    assert.strictEqual(bufToHex(profile.encode()), '7805')
+  })
+
+  await t.test('decodes docUrl', () => {
+    assert.strictEqual(Number(Profile.decode(hexToBuf('7805')).docUrl), 5)
+  })
+
+  await t.test('defaults docUrl to 0 when absent', () => {
+    assert.strictEqual(Number(new Profile().docUrl), 0)
+  })
+})
+
 function encodeStringTable(strings: StringTable) {
   return strings.strings.map(s => {
     const buf = new TextEncoder().encode(s)

--- a/src/index.ts
+++ b/src/index.ts
@@ -701,11 +701,13 @@ export class Mapping {
 export type LineInput = {
   functionId?: Numeric
   line?: Numeric
+  column?: Numeric
 }
 
 export class Line {
   functionId: Numeric
   line: Numeric
+  column: Numeric
 
   static create(data: LineInput): Line {
     return data instanceof Line ? data : new Line(data)
@@ -714,12 +716,14 @@ export class Line {
   constructor(data: LineInput) {
     this.functionId = data.functionId || 0
     this.line = data.line || 0
+    this.column = data.column || 0
   }
 
   get length() {
     let total = 0
     total += measureNumberField(this.functionId)
     total += measureNumberField(this.line)
+    total += measureNumberField(this.column)
     return total
   }
 
@@ -732,6 +736,11 @@ export class Line {
     if (this.line) {
       buffer[offset++] = 16 // (2 << 3) + kTypeVarInt
       offset = encodeNumber(buffer, offset, this.line)
+    }
+
+    if (this.column) {
+      buffer[offset++] = 24 // (3 << 3) + kTypeVarInt
+      offset = encodeNumber(buffer, offset, this.column)
     }
 
     return offset
@@ -749,6 +758,9 @@ export class Line {
         break
       case 2:
         data.line = decodeNumber(buffer)
+        break
+      case 3:
+        data.column = decodeNumber(buffer)
         break
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -970,6 +970,7 @@ export type ProfileInput = {
   period?: Numeric
   comment?: Array<Numeric>
   defaultSampleType?: Numeric
+  docUrl?: Numeric
 }
 
 export class Profile {
@@ -987,6 +988,7 @@ export class Profile {
   period: Numeric
   comment: Array<Numeric>
   defaultSampleType: Numeric
+  docUrl: Numeric
 
   constructor(data: ProfileInput = {}) {
     this.sampleType = (data.sampleType || []).map(ValueType.create)
@@ -1003,6 +1005,7 @@ export class Profile {
     this.period = data.period || 0
     this.comment = data.comment || []
     this.defaultSampleType = data.defaultSampleType || 0
+    this.docUrl = data.docUrl || 0
   }
 
   get length() {
@@ -1021,6 +1024,7 @@ export class Profile {
     total += measureNumberField(this.period)
     total += measureNumberArrayField(this.comment)
     total += measureNumberField(this.defaultSampleType)
+    total += measureNumberField(this.docUrl)
     return total
   }
 
@@ -1112,6 +1116,11 @@ export class Profile {
     if (this.defaultSampleType) {
       buffer[offset++] = 112 // (14 << 3) + kTypeVarInt
       offset = encodeNumber(buffer, offset, this.defaultSampleType)
+    }
+
+    if (this.docUrl) {
+      buffer[offset++] = 120 // (15 << 3) + kTypeVarInt
+      offset = encodeNumber(buffer, offset, this.docUrl)
     }
 
     return offset
@@ -1208,6 +1217,9 @@ export class Profile {
         break
       case 14:
         data.defaultSampleType = decodeNumber(buffer)
+        break
+      case 15:
+        data.docUrl = decodeNumber(buffer)
         break
     }
   }

--- a/testing/proto/profile.d.ts
+++ b/testing/proto/profile.d.ts
@@ -788,6 +788,9 @@ export namespace perftools {
 
             /** Line line */
             line?: (number|Long|null);
+
+            /** Line column */
+            column?: (number|Long|null);
         }
 
         /** Represents a Line. */
@@ -804,6 +807,9 @@ export namespace perftools {
 
             /** Line line. */
             public line: (number|Long);
+
+            /** Line column. */
+            public column: (number|Long);
 
             /**
              * Creates a new Line instance using the specified properties.

--- a/testing/proto/profile.d.ts
+++ b/testing/proto/profile.d.ts
@@ -50,6 +50,9 @@ export namespace perftools {
 
             /** Profile defaultSampleType */
             defaultSampleType?: (number|Long|null);
+
+            /** Profile docUrl */
+            docUrl?: (number|Long|null);
         }
 
         /** Represents a Profile. */
@@ -102,6 +105,9 @@ export namespace perftools {
 
             /** Profile defaultSampleType. */
             public defaultSampleType: (number|Long);
+
+            /** Profile docUrl. */
+            public docUrl: (number|Long);
 
             /**
              * Creates a new Profile instance using the specified properties.

--- a/testing/proto/profile.js
+++ b/testing/proto/profile.js
@@ -2562,6 +2562,7 @@ $root.perftools = (function() {
              * @interface ILine
              * @property {number|Long|null} [functionId] Line functionId
              * @property {number|Long|null} [line] Line line
+             * @property {number|Long|null} [column] Line column
              */
 
             /**
@@ -2596,6 +2597,14 @@ $root.perftools = (function() {
             Line.prototype.line = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
             /**
+             * Line column.
+             * @member {number|Long} column
+             * @memberof perftools.profiles.Line
+             * @instance
+             */
+            Line.prototype.column = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+            /**
              * Creates a new Line instance using the specified properties.
              * @function create
              * @memberof perftools.profiles.Line
@@ -2623,6 +2632,8 @@ $root.perftools = (function() {
                     writer.uint32(/* id 1, wireType 0 =*/8).uint64(message.functionId);
                 if (message.line != null && Object.hasOwnProperty.call(message, "line"))
                     writer.uint32(/* id 2, wireType 0 =*/16).int64(message.line);
+                if (message.column != null && Object.hasOwnProperty.call(message, "column"))
+                    writer.uint32(/* id 3, wireType 0 =*/24).int64(message.column);
                 return writer;
             };
 
@@ -2663,6 +2674,10 @@ $root.perftools = (function() {
                         }
                     case 2: {
                             message.line = reader.int64();
+                            break;
+                        }
+                    case 3: {
+                            message.column = reader.int64();
                             break;
                         }
                     default:
@@ -2706,6 +2721,9 @@ $root.perftools = (function() {
                 if (message.line != null && message.hasOwnProperty("line"))
                     if (!$util.isInteger(message.line) && !(message.line && $util.isInteger(message.line.low) && $util.isInteger(message.line.high)))
                         return "line: integer|Long expected";
+                if (message.column != null && message.hasOwnProperty("column"))
+                    if (!$util.isInteger(message.column) && !(message.column && $util.isInteger(message.column.low) && $util.isInteger(message.column.high)))
+                        return "column: integer|Long expected";
                 return null;
             };
 
@@ -2739,6 +2757,15 @@ $root.perftools = (function() {
                         message.line = object.line;
                     else if (typeof object.line === "object")
                         message.line = new $util.LongBits(object.line.low >>> 0, object.line.high >>> 0).toNumber();
+                if (object.column != null)
+                    if ($util.Long)
+                        (message.column = $util.Long.fromValue(object.column)).unsigned = false;
+                    else if (typeof object.column === "string")
+                        message.column = parseInt(object.column, 10);
+                    else if (typeof object.column === "number")
+                        message.column = object.column;
+                    else if (typeof object.column === "object")
+                        message.column = new $util.LongBits(object.column.low >>> 0, object.column.high >>> 0).toNumber();
                 return message;
             };
 
@@ -2766,6 +2793,11 @@ $root.perftools = (function() {
                         object.line = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                     } else
                         object.line = options.longs === String ? "0" : 0;
+                    if ($util.Long) {
+                        var long = new $util.Long(0, 0, false);
+                        object.column = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                    } else
+                        object.column = options.longs === String ? "0" : 0;
                 }
                 if (message.functionId != null && message.hasOwnProperty("functionId"))
                     if (typeof message.functionId === "number")
@@ -2777,6 +2809,11 @@ $root.perftools = (function() {
                         object.line = options.longs === String ? String(message.line) : message.line;
                     else
                         object.line = options.longs === String ? $util.Long.prototype.toString.call(message.line) : options.longs === Number ? new $util.LongBits(message.line.low >>> 0, message.line.high >>> 0).toNumber() : message.line;
+                if (message.column != null && message.hasOwnProperty("column"))
+                    if (typeof message.column === "number")
+                        object.column = options.longs === String ? String(message.column) : message.column;
+                    else
+                        object.column = options.longs === String ? $util.Long.prototype.toString.call(message.column) : options.longs === Number ? new $util.LongBits(message.column.low >>> 0, message.column.high >>> 0).toNumber() : message.column;
                 return object;
             };
 

--- a/testing/proto/profile.js
+++ b/testing/proto/profile.js
@@ -47,6 +47,7 @@ $root.perftools = (function() {
              * @property {number|Long|null} [period] Profile period
              * @property {Array.<number|Long>|null} [comment] Profile comment
              * @property {number|Long|null} [defaultSampleType] Profile defaultSampleType
+             * @property {number|Long|null} [docUrl] Profile docUrl
              */
 
             /**
@@ -184,6 +185,14 @@ $root.perftools = (function() {
             Profile.prototype.defaultSampleType = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
             /**
+             * Profile docUrl.
+             * @member {number|Long} docUrl
+             * @memberof perftools.profiles.Profile
+             * @instance
+             */
+            Profile.prototype.docUrl = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+            /**
              * Creates a new Profile instance using the specified properties.
              * @function create
              * @memberof perftools.profiles.Profile
@@ -245,6 +254,8 @@ $root.perftools = (function() {
                 }
                 if (message.defaultSampleType != null && Object.hasOwnProperty.call(message, "defaultSampleType"))
                     writer.uint32(/* id 14, wireType 0 =*/112).int64(message.defaultSampleType);
+                if (message.docUrl != null && Object.hasOwnProperty.call(message, "docUrl"))
+                    writer.uint32(/* id 15, wireType 0 =*/120).int64(message.docUrl);
                 return writer;
             };
 
@@ -352,6 +363,10 @@ $root.perftools = (function() {
                         }
                     case 14: {
                             message.defaultSampleType = reader.int64();
+                            break;
+                        }
+                    case 15: {
+                            message.docUrl = reader.int64();
                             break;
                         }
                     default:
@@ -471,6 +486,9 @@ $root.perftools = (function() {
                 if (message.defaultSampleType != null && message.hasOwnProperty("defaultSampleType"))
                     if (!$util.isInteger(message.defaultSampleType) && !(message.defaultSampleType && $util.isInteger(message.defaultSampleType.low) && $util.isInteger(message.defaultSampleType.high)))
                         return "defaultSampleType: integer|Long expected";
+                if (message.docUrl != null && message.hasOwnProperty("docUrl"))
+                    if (!$util.isInteger(message.docUrl) && !(message.docUrl && $util.isInteger(message.docUrl.low) && $util.isInteger(message.docUrl.high)))
+                        return "docUrl: integer|Long expected";
                 return null;
             };
 
@@ -616,6 +634,15 @@ $root.perftools = (function() {
                         message.defaultSampleType = object.defaultSampleType;
                     else if (typeof object.defaultSampleType === "object")
                         message.defaultSampleType = new $util.LongBits(object.defaultSampleType.low >>> 0, object.defaultSampleType.high >>> 0).toNumber();
+                if (object.docUrl != null)
+                    if ($util.Long)
+                        (message.docUrl = $util.Long.fromValue(object.docUrl)).unsigned = false;
+                    else if (typeof object.docUrl === "string")
+                        message.docUrl = parseInt(object.docUrl, 10);
+                    else if (typeof object.docUrl === "number")
+                        message.docUrl = object.docUrl;
+                    else if (typeof object.docUrl === "object")
+                        message.docUrl = new $util.LongBits(object.docUrl.low >>> 0, object.docUrl.high >>> 0).toNumber();
                 return message;
             };
 
@@ -673,6 +700,11 @@ $root.perftools = (function() {
                         object.defaultSampleType = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                     } else
                         object.defaultSampleType = options.longs === String ? "0" : 0;
+                    if ($util.Long) {
+                        var long = new $util.Long(0, 0, false);
+                        object.docUrl = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                    } else
+                        object.docUrl = options.longs === String ? "0" : 0;
                 }
                 if (message.sampleType && message.sampleType.length) {
                     object.sampleType = [];
@@ -744,6 +776,11 @@ $root.perftools = (function() {
                         object.defaultSampleType = options.longs === String ? String(message.defaultSampleType) : message.defaultSampleType;
                     else
                         object.defaultSampleType = options.longs === String ? $util.Long.prototype.toString.call(message.defaultSampleType) : options.longs === Number ? new $util.LongBits(message.defaultSampleType.low >>> 0, message.defaultSampleType.high >>> 0).toNumber() : message.defaultSampleType;
+                if (message.docUrl != null && message.hasOwnProperty("docUrl"))
+                    if (typeof message.docUrl === "number")
+                        object.docUrl = options.longs === String ? String(message.docUrl) : message.docUrl;
+                    else
+                        object.docUrl = options.longs === String ? $util.Long.prototype.toString.call(message.docUrl) : options.longs === Number ? new $util.LongBits(message.docUrl.low >>> 0, message.docUrl.high >>> 0).toNumber() : message.docUrl;
                 return object;
             };
 

--- a/testing/proto/profile.proto
+++ b/testing/proto/profile.proto
@@ -205,6 +205,8 @@ message Line {
   uint64 function_id = 1;
   // Line number in source code.
   int64 line = 2;
+  // Column number in source code.
+  int64 column = 3;
 }
 
 message Function {

--- a/testing/proto/profile.proto
+++ b/testing/proto/profile.proto
@@ -93,6 +93,8 @@ message Profile {
   // Index into the string table of the type of the preferred sample
   // value. If unset, clients should default to the last sample value.
   int64 default_sample_type = 14;
+  // Documentation link for this profile. Index into string table.
+  int64 doc_url = 15;
 }
 
 // ValueType describes the semantics and measurement units of a value.


### PR DESCRIPTION
Release proposal for **v2.3.0** (from v2.2.3), cherry-picked from `main`.

# New features
* #80 — add `column` field to Line message
* #81 — add `doc_url` field to Profile message

# Other (build, dev)
* #78 — bump the patch-updates group (2 updates)
* #79 — bump the minor-updates group (2 updates)
* #82 — ignore TypeScript major-version bumps in dependabot
* #83 — bump the minor-updates group (2 updates)

---
Verified locally on the combined branch: `npm ci`, `npm run lint`, and `npm test` (80/80) all pass.